### PR TITLE
Custom transmutation and more

### DIFF
--- a/docs/sticky-filters.md
+++ b/docs/sticky-filters.md
@@ -1,0 +1,40 @@
+# Sticky Filters
+
+A required filter that when present in a `FilterSet`
+will produce filter criteria regardless of user input,
+unless the user has explcitly overriden the default.
+This concept is called a _sticky filter_
+because the filter stuck to the filterset like gum on the bottom of a shoe.
+
+A sticky filter is present in the `FilterSet`'s query regardless of the user's input.
+It's not until the user sets this filter explicitly
+to the _solvent_ value--usually a choice--that the filter
+will be removed from the overall query.
+
+For example, say we define a `FilterSet` for a task model
+where our desire is that the model's ``status`` field be `'complete'`.
+We also want to enable the user to search for `'any'` status,
+which will remove the criteria from the query.
+We can achieve this by providing a sticky filter
+that defaults to the desired value (i.e. `'complete'`),
+but does not produce a query filter
+when the value results in the solvent value (e.g. empty string or keyword).
+
+    class TaskFilterSet(FilterSet):
+        STATUS_CHOICES = [
+            ('any', 'Any'),
+            ('p', 'Pending'),
+            ('c', 'Complete'),
+        ]
+        status = Filter(
+            ChoiceLookup('exact', label='is', choices=STATUS_CHOICES),
+            sticky_value='c',
+            solvent_value='any',
+            label="Status",
+        )
+        # ...
+
+The two parameters that make a Filter sticky are
+`sticky_value` to set the default value for the query
+and
+`solvent_value` to allow the user to remove the filter from the query.

--- a/src/django_filtering/filters.py
+++ b/src/django_filtering/filters.py
@@ -102,7 +102,7 @@ class Filter:
             raise ValueError("At this time, the filter label must be provided.")
         self.label = label
 
-    def get_options_schema_info(self, field):
+    def get_options_schema_info(self, field, queryset):
         lookups = {}
         for lu in self.lookups:
             lookups[lu.name] = lu.get_options_schema_definition(field)
@@ -121,7 +121,7 @@ class Filter:
         """
         return value
 
-    def translate_to_Q_arg(self, value, **kwargs) -> Tuple[str, Any] | None:
+    def translate_to_Q_arg(self, value, queryset, **kwargs) -> Tuple[str, Any] | None:
         """
         Translates the query data criteria to a Q argument.
         """
@@ -184,14 +184,14 @@ class StickyFilter(Filter):
             return UNSTICK_VALUE
         return value
 
-    def get_sticky_Q_arg(self) -> Tuple[str, Any]:
+    def get_sticky_Q_arg(self, queryset) -> Tuple[str, Any]:
         """
         Returns the sticky Q argument
         to be used when the filter is not within the user input.
         """
-        return self.translate_to_Q_arg(value=self.default_value)
+        return self.translate_to_Q_arg(value=self.default_value, queryset=queryset)
 
-    def translate_to_Q_arg(self, value, **kwargs) -> Tuple[str, Any] | None:
+    def translate_to_Q_arg(self, value, queryset, **kwargs) -> Tuple[str, Any] | None:
         """
         Translates the query data criteria to a Q argument.
         """
@@ -207,8 +207,8 @@ class StickyFilter(Filter):
             lookup,
         )
 
-    def get_options_schema_info(self, field):
-        info = super().get_options_schema_info(field)
+    def get_options_schema_info(self, field, queryset):
+        info = super().get_options_schema_info(field, queryset)
         info['is_sticky'] = True
-        info['sticky_default'] = deconstruct_field_lookup_arg(*self.get_sticky_Q_arg())
+        info['sticky_default'] = deconstruct_field_lookup_arg(*self.get_sticky_Q_arg(queryset))
         return info

--- a/src/django_filtering/filters.py
+++ b/src/django_filtering/filters.py
@@ -151,10 +151,11 @@ class Filter:
     to auto-select the lookup relationship.
     The ``label`` is the human readable name of the field.
 
-    The ``name`` attribute is assigned by the FilterSet's metaclass.
+    The ``_name`` attribute is assigned by the FilterSet's metaclass
+    through the ``bind`` method.
+
     """
     _name = None
-    filterset = None
 
     def __init__(
         self,
@@ -184,14 +185,13 @@ class Filter:
     def name(self):
         return self._name
 
-    def bind(self, name: str, filterset: 'FilterSet') -> 'Filter':
+    def bind(self, name: str) -> 'Filter':
         """
-        Returns a copy of this filter,
-        with assignments from the given ``name`` and ``filterset`` instance.
+        Returns a copy of this filter with assignments from the given ``name``,
+        which is the name given to the Filter in the FilterSet.
         """
         filter = deepcopy(self)
         filter._name = name
-        filter.filterset = filterset
         return filter
 
     @property

--- a/src/django_filtering/filters.py
+++ b/src/django_filtering/filters.py
@@ -155,7 +155,7 @@ class Filter:
 
     The ``name`` attribute is assigned by the FilterSet's metaclass.
     """
-    name = None
+    _name = None
     filterset = None
 
     def __init__(
@@ -182,13 +182,17 @@ class Filter:
         self.sticky_value = sticky_value
         self.solvent_value = solvent_value
 
+    @property
+    def name(self):
+        return self._name
+
     def bind(self, name: str, filterset: 'FilterSet') -> 'Filter':
         """
         Returns a copy of this filter,
         with assignments from the given ``name`` and ``filterset`` instance.
         """
         filter = deepcopy(self)
-        filter.name = name
+        filter._name = name
         filter.filterset = filterset
         filter.model = filterset._meta.model
         return filter

--- a/src/django_filtering/filters.py
+++ b/src/django_filtering/filters.py
@@ -112,6 +112,35 @@ class ChoiceLookup(SingleFieldLookup):
         return definition
 
 
+class DateRangeLookup(Lookup):
+    """
+    Represents inputs for querying between a date range.
+
+    """
+    type = 'date-range'
+
+    # At this time there is no reason to _clean_ the value
+    # and turn it into a `datetime.date`.
+    # The database is capable of casting a string to its native date type
+    # as long we enforce iso 8601 formatting.
+
+    def transmute(self, **kwargs):
+        filter = kwargs['filter']
+        criteria = kwargs['criteria']
+        return Q(
+            construct_field_lookup_arg(
+                filter.name,
+                criteria['value'][0],
+                'gte',
+            ),
+            construct_field_lookup_arg(
+                filter.name,
+                criteria['value'][1],
+                'lte',
+            )
+        )
+
+
 # A sentry value used to signal when the user has selected
 # to remove the sticky filter.
 STICKY_SOLVENT_VALUE = object()

--- a/src/django_filtering/filters.py
+++ b/src/django_filtering/filters.py
@@ -1,4 +1,4 @@
-from typing import Any, Tuple
+from copy import deepcopy
 
 from django.db.models import Q
 
@@ -91,6 +91,7 @@ class Filter:
     The ``name`` attribute is assigned by the FilterSet's metaclass.
     """
     name = None
+    filterset = None
 
     def __init__(
         self,
@@ -115,6 +116,16 @@ class Filter:
         # and solvent value that removes the sticky value from the resulting query.
         self.sticky_value = sticky_value
         self.solvent_value = solvent_value
+
+    def bind(self, name: str, filterset: 'FilterSet') -> 'Filter':
+        """
+        Returns a copy of this filter,
+        with assignments from the given ``name`` and ``filterset`` instance.
+        """
+        filter = deepcopy(self)
+        filter.name = name
+        filter.filterset = filterset
+        return filter
 
     @property
     def is_sticky(self):

--- a/src/django_filtering/filterset.py
+++ b/src/django_filtering/filterset.py
@@ -5,7 +5,7 @@ import jsonschema
 from django.conf import settings
 from django.db.models import Q, QuerySet
 
-from .filters import Filter, StickyFilter
+from .filters import Filter
 from .schema import JSONSchema, FilteringOptionsSchema
 from .utils import merge_dicts
 
@@ -64,7 +64,7 @@ class Metadata:
 
     @property
     def sticky_filters(self) -> List[Filter]:
-        return [f for f in self.filters if isinstance(f, StickyFilter)]
+        return [f for f in self.filters if f.is_sticky]
 
 
 class FilterSetType(type):

--- a/src/django_filtering/filterset.py
+++ b/src/django_filtering/filterset.py
@@ -152,18 +152,14 @@ class FilterSet(metaclass=FilterSetType):
     def sticky_filters(self):
         return self._meta.sticky_filters
 
-    def get_queryset(self):
-        return self._meta.model.objects.all()
-
-    def filter_queryset(self, queryset=None) -> QuerySet:
+    def filter_queryset(self, queryset) -> QuerySet:
         if not self.is_valid:
             raise InvalidFilterSet(
                 "The query is invalid! "
                 "Hint, check `is_valid` before running `filter_queryset`.\n"
                 f"Errors:\n{self._errors}"
             )
-        if queryset is None:
-            queryset = self.get_queryset()
+
         if self.query:
             queryset = queryset.filter(self.query)
         return queryset

--- a/src/django_filtering/filterset.py
+++ b/src/django_filtering/filterset.py
@@ -1,6 +1,6 @@
 import warnings
 from functools import cached_property
-from typing import Any, List, Tuple
+from typing import Any
 
 import jsonschema
 from django.conf import settings
@@ -8,7 +8,6 @@ from django.db.models import Q, QuerySet
 
 from .filters import Filter
 from .schema import JSONSchema, FilteringOptionsSchema
-from .utils import merge_dicts
 
 
 class MetadataException(Exception):

--- a/src/django_filtering/filterset.py
+++ b/src/django_filtering/filterset.py
@@ -297,8 +297,8 @@ class FilterSet(metaclass=FilterSetType):
 
         Sticky filters are applied when the user provided query data
         does not contain the sticky filter
-        or when the default value has been set to anything other than
-        the __unstick value__.
+        or when the sticky or default value have been set to anything other than
+        the solvent value.
         """
         # Define the set of filter names used in the current query data.
         if len(self.query_data) >= 2:
@@ -312,13 +312,6 @@ class FilterSet(metaclass=FilterSetType):
             if sf.name not in query_data_filter_names:
                 # Anding the sticky filter's default Q
                 sticky_q &= sf.get_sticky_Q(queryset=queryset)
-            # Note, at this point in the process,
-            # the sticky filter should not be part of the Q set,
-            # because the UNSTICK_VALUE has prevented it from being included.
-            # This assumes that `_make_Q`, and supporting method on `Filter`,
-            # are correctly implemented to exclude the filter from the Q set.
-            # Reminder, it is necessary for the sticky filter
-            # to be in the query data in order for it to be unstuck.
 
         return sticky_q & q if q else sticky_q
 

--- a/src/django_filtering/schema.py
+++ b/src/django_filtering/schema.py
@@ -17,7 +17,7 @@ class FilteringOptionsSchema:
         }
         filters = {
             f.name: f.get_options_schema_info(
-                self.filterset.get_default_queryset(),
+                context=self.filterset.make_context(filter=f)
             )
             for f in self.filterset.filters
         }

--- a/src/django_filtering/schema.py
+++ b/src/django_filtering/schema.py
@@ -85,7 +85,8 @@ class JSONSchema:
                         "type": "object",
                         "properties": {
                             "lookup": {"enum": [l.name for l in filter.lookups]},
-                            "value": {"type": "string"},
+                            # TODO Restrict value types to desired input type.
+                            "value": {"type": ["string", "number", "object", "array", "boolean", "null"]},
                         },
                     },
                 ],

--- a/src/django_filtering/schema.py
+++ b/src/django_filtering/schema.py
@@ -16,7 +16,10 @@ class FilteringOptionsSchema:
             "not": {"type": "operator", "label": "None of..."},
         }
         filters = {
-            f.name: f.get_options_schema_info(self._get_field(f.name))
+            f.name: f.get_options_schema_info(
+                self._get_field(f.name),
+                self.filterset.get_default_queryset(),
+            )
             for f in self.filterset.filters
         }
         return {

--- a/src/django_filtering/schema.py
+++ b/src/django_filtering/schema.py
@@ -17,7 +17,6 @@ class FilteringOptionsSchema:
         }
         filters = {
             f.name: f.get_options_schema_info(
-                self._get_field(f.name),
                 self.filterset.get_default_queryset(),
             )
             for f in self.filterset.filters

--- a/src/django_filtering/utils.py
+++ b/src/django_filtering/utils.py
@@ -1,5 +1,8 @@
 from typing import Any, Dict, List, Optional, Tuple
 
+from django.db.models import Q
+
+
 # An arugment to the Q class
 QArg = Tuple[str, Any]
 QueryDataVar = List[str | Dict[str, Any]]
@@ -35,21 +38,21 @@ def construct_field_lookup_arg(
     return (construct_field_lookup_name(field_name, lookup=lookup), value)
 
 
-def deconstruct_field_lookup_arg(
-    field_lookup: str,
-    value: Any,
-    lookup: Optional[str | List[str]] = None,
+def deconstruct_query(
+    query: Q,
 ) -> QueryDataVar:
     """
-    Given a field name with lookup value,
+    Given a query (Q),
     deconstruct it into a __query data__ structure.
     """
+    if len(query.children) >= 2:
+        raise ValueError("Can only handle deconstruction of a single query value")
+    field_lookup, value = query.children[0]
     name, *lookups = field_lookup.split("__")
     if not lookups:
-        lookups = lookup if lookup else 'exact'
-    elif len(lookups) == 1:
+        lookups = 'exact'
+    elif isinstance(lookups, list) and len(lookups) == 1:
         lookups = lookups[0]
-
     opts = {'value': value}
     if lookups: opts['lookup'] = lookups
     return [name, opts]

--- a/tests/lab_app/filters.py
+++ b/tests/lab_app/filters.py
@@ -29,7 +29,7 @@ class StudyFilterSet(filtering.FilterSet):
         ),
         default_lookup='exact',
         label="Continent",
-        translator=utils.continent_to_countries,
+        transmuter=utils.continent_to_countries,
     )
 
     class Meta:

--- a/tests/lab_app/filters.py
+++ b/tests/lab_app/filters.py
@@ -32,7 +32,7 @@ class StudyFilterSet(filtering.FilterSet):
         label="Continent",
     )
 
-    def transmute_continent(self, criteria, **kwargs):
+    def transmute_continent(self, criteria, context):
         country_codes = utils.continent_to_countries(criteria['value'])
         return Q(country__in=country_codes)
 

--- a/tests/lab_app/filters.py
+++ b/tests/lab_app/filters.py
@@ -1,6 +1,7 @@
 import django_filtering as filtering
 
 from . import models
+from . import utils
 
 
 class ParticipantFilterSet(filtering.FilterSet):
@@ -12,3 +13,24 @@ class ParticipantFilterSet(filtering.FilterSet):
 
     class Meta:
         model = models.Participant
+
+
+class StudyFilterSet(filtering.FilterSet):
+    name = filtering.Filter(
+        filtering.InputLookup('icontains', label='contains'),
+        default_lookup='icontains',
+        label="Name",
+    )
+    continent = filtering.Filter(
+        filtering.ChoiceLookup(
+            "exact",
+            label="is",
+            choices=utils.CONTINENT_CHOICES,
+        ),
+        default_lookup='exact',
+        label="Continent",
+        translator=utils.continent_to_countries,
+    )
+
+    class Meta:
+        model = models.Study

--- a/tests/lab_app/filters.py
+++ b/tests/lab_app/filters.py
@@ -1,3 +1,5 @@
+from django.db.models import Q
+
 import django_filtering as filtering
 
 from . import models
@@ -27,10 +29,12 @@ class StudyFilterSet(filtering.FilterSet):
             label="is",
             choices=utils.CONTINENT_CHOICES,
         ),
-        default_lookup='exact',
         label="Continent",
-        transmuter=utils.continent_to_countries,
     )
+
+    def transmute_continent(self, criteria, **kwargs):
+        country_codes = utils.continent_to_countries(criteria['value'])
+        return Q(country__in=country_codes)
 
     class Meta:
         model = models.Study

--- a/tests/lab_app/models.py
+++ b/tests/lab_app/models.py
@@ -34,5 +34,6 @@ class Study(models.Model):
         CLOSE = 40, "Closed"
 
     name = models.CharField(max_length=255)
+    country = models.CharField(max_length=3)  # ISO 3166-1 alpha-3
     state = models.IntegerField(choices=State, default=State.DRAFT)
     participants = models.ManyToManyField(Participant, blank=True)

--- a/tests/lab_app/utils.py
+++ b/tests/lab_app/utils.py
@@ -1,6 +1,3 @@
-from django.db.models import Q
-
-
 CONTINENT_CHOICES = [
     ('AS', 'Asia'),
     ('AF', 'Africa'),
@@ -16,7 +13,7 @@ CONTINENT_COUNTRIES_MAP = {
     'NA': ['CAN', 'MEX', 'USA', 'BMU', 'GRL']
 }
 
-def continent_to_countries(value, queryset, **kwargs) -> Q:
+def continent_to_countries(value) -> list[str]:
     if value != 'NA':
         raise Exception("Testing scope is limited to the 'NA' choice.")
-    return Q(country__in=CONTINENT_COUNTRIES_MAP[value])
+    return CONTINENT_COUNTRIES_MAP[value]

--- a/tests/lab_app/utils.py
+++ b/tests/lab_app/utils.py
@@ -1,3 +1,6 @@
+from django.db.models import Q
+
+
 CONTINENT_CHOICES = [
     ('AS', 'Asia'),
     ('AF', 'Africa'),
@@ -13,8 +16,7 @@ CONTINENT_COUNTRIES_MAP = {
     'NA': ['CAN', 'MEX', 'USA', 'BMU', 'GRL']
 }
 
-def continent_to_countries(value, queryset, **kwargs):
+def continent_to_countries(value, queryset, **kwargs) -> Q:
     if value != 'NA':
         raise Exception("Testing scope is limited to the 'NA' choice.")
-
-    return ('country__in', CONTINENT_COUNTRIES_MAP[value])
+    return Q(country__in=CONTINENT_COUNTRIES_MAP[value])

--- a/tests/lab_app/utils.py
+++ b/tests/lab_app/utils.py
@@ -1,0 +1,20 @@
+CONTINENT_CHOICES = [
+    ('AS', 'Asia'),
+    ('AF', 'Africa'),
+    ('NA', 'North America'),
+    ('SA', 'South America'),
+    ('AN', 'Antarctica'),
+    ('EU', 'Europe'),
+    ('AU', 'Australia'),
+]
+
+CONTINENT_COUNTRIES_MAP = {
+    # An incomplete list of ISO 3166-1 alpha-3 country codes for North America
+    'NA': ['CAN', 'MEX', 'USA', 'BMU', 'GRL']
+}
+
+def continent_to_countries(value, queryset, **kwargs):
+    if value != 'NA':
+        raise Exception("Testing scope is limited to the 'NA' choice.")
+
+    return ('country__in', CONTINENT_COUNTRIES_MAP[value])

--- a/tests/market_app/filters.py
+++ b/tests/market_app/filters.py
@@ -1,15 +1,9 @@
+from django.db.models import Q
+
 import django_filtering as filtering
 
 from . import models
 
-
-def query_in_stock(value, queryset, **kwargs):
-    from django.db.models import Q
-
-    if value is True:
-        return Q(quantity__gt=0)
-    else:
-        return Q(quantity__lt=0)
 
 class ProductFilterSet(filtering.FilterSet):
     name = filtering.Filter(
@@ -36,8 +30,15 @@ class ProductFilterSet(filtering.FilterSet):
     is_in_stock = filtering.Filter(
         filtering.ChoiceLookup('exact', label=":", choices=[(True, "Yes"), (False, "No")]),
         label="Is in stock?",
-        transmuter=query_in_stock,
     )
+
+    def transmute_is_in_stock(self, **kwargs):
+        value = kwargs['criteria']['value']
+
+        if value is True:
+            return Q(quantity__gt=0)
+        else:
+            return Q(quantity__lte=0)
 
     class Meta:
         model = models.Product

--- a/tests/market_app/filters.py
+++ b/tests/market_app/filters.py
@@ -15,6 +15,7 @@ class ProductFilterSet(filtering.FilterSet):
         label="Category",
     )
     stocked_on = filtering.Filter(
+        filtering.DateRangeLookup('range', label="between"),
         filtering.InputLookup(['year', 'gte'], label="year >="),
         label="Stocked",
     )

--- a/tests/market_app/filters.py
+++ b/tests/market_app/filters.py
@@ -30,10 +30,10 @@ class KitchenProductFilterSet(filtering.FilterSet):
         filtering.InputLookup('icontains', label="contains"),
         label="Name",
     )
-    category = filtering.StickyFilter(
+    category = filtering.Filter(
         filtering.ChoiceLookup('exact', label="equals"),
-        unstick_value='',
-        default_value="Kitchen",
+        solvent_value='',
+        sticky_value="Kitchen",
         label="Category",
     )
     class Meta:
@@ -47,9 +47,9 @@ class TopBrandKitchenProductFilterSet(KitchenProductFilterSet):
         ('MOEN', 'MOEN'),
         ('Glacier Bay', 'Glacier Bay'),
     ]
-    brand = filtering.StickyFilter(
+    brand = filtering.Filter(
         filtering.ChoiceLookup('exact', label='is', choices=BRAND_CHOICES),
-        default_value="MOEN",
-        unstick_value='all',
+        sticky_value="MOEN",
+        solvent_value='all',
         label="Brand",
     )

--- a/tests/market_app/filters.py
+++ b/tests/market_app/filters.py
@@ -3,6 +3,14 @@ import django_filtering as filtering
 from . import models
 
 
+def query_in_stock(value, queryset, **kwargs):
+    from django.db.models import Q
+
+    if value is True:
+        return Q(quantity__gt=0)
+    else:
+        return Q(quantity__lt=0)
+
 class ProductFilterSet(filtering.FilterSet):
     name = filtering.Filter(
         filtering.InputLookup('icontains', label='contains'),
@@ -16,9 +24,19 @@ class ProductFilterSet(filtering.FilterSet):
         filtering.InputLookup(['year', 'gte'], label="year >="),
         label="Stocked",
     )
+    quantity = filtering.Filter(
+        filtering.InputLookup(['gte'], label=">="),
+        label="Quantity",
+    )
     brand = filtering.Filter(
         filtering.InputLookup('exact', label="is"),
         label="Brand",
+    )
+
+    is_in_stock = filtering.Filter(
+        filtering.ChoiceLookup('exact', label=":", choices=[(True, "Yes"), (False, "No")]),
+        label="Is in stock?",
+        transmuter=query_in_stock,
     )
 
     class Meta:

--- a/tests/market_app/filters.py
+++ b/tests/market_app/filters.py
@@ -12,7 +12,7 @@ class ProductFilterSet(filtering.FilterSet):
         filtering.ChoiceLookup('in', label="in"),
         label="Category",
     )
-    stocked = filtering.Filter(
+    stocked_on = filtering.Filter(
         filtering.InputLookup(['year', 'gte'], label="year >="),
         label="Stocked",
     )

--- a/tests/market_app/filters.py
+++ b/tests/market_app/filters.py
@@ -33,8 +33,8 @@ class ProductFilterSet(filtering.FilterSet):
         label="Is in stock?",
     )
 
-    def transmute_is_in_stock(self, **kwargs):
-        value = kwargs['criteria']['value']
+    def transmute_is_in_stock(self, criteria, context):
+        value = criteria['value']
 
         if value is True:
             return Q(quantity__gt=0)

--- a/tests/market_app/models.py
+++ b/tests/market_app/models.py
@@ -11,6 +11,7 @@ class Product(models.Model):
     name = models.CharField(max_length=255)
     category = models.CharField(max_length=255, choices=Category)
     stocked_on = models.DateTimeField()
+    quantity = models.IntegerField()
     brand = models.CharField(max_length=255)
 
     def __str__(self):

--- a/tests/market_app/models.py
+++ b/tests/market_app/models.py
@@ -10,7 +10,7 @@ class Product(models.Model):
 
     name = models.CharField(max_length=255)
     category = models.CharField(max_length=255, choices=Category)
-    stocked = models.DateTimeField()
+    stocked_on = models.DateTimeField()
     brand = models.CharField(max_length=255)
 
     def __str__(self):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -170,7 +170,7 @@ class TestFilter:
         }
         assert options_schema_info == expected
 
-    def test_translate_to_Q_arg(self):
+    def test_transmute(self):
         label = "Pages"
         choices = [
             ('10', '10'),
@@ -193,7 +193,7 @@ class TestFilter:
 
         # Check translation of _query data's criteria_ to django Q argument
         criteria = {'lookup': 'gte', 'value': '50'}
-        assert filter.translate_to_Q_arg(**criteria, queryset=None) == ('pages__gte', '50')
+        assert filter.transmute(**criteria, queryset=None) == models.Q(pages__gte='50')
 
 
 class TestStickyFilter:
@@ -226,11 +226,11 @@ class TestStickyFilter:
 
         # Check translation of query data's criteria to django Q argument
         criteria = {'lookup': 'exact', 'value': 'bulk'}
-        assert filter.translate_to_Q_arg(**criteria, queryset=None) == ('type__exact', 'bulk')
+        assert filter.transmute(**criteria, queryset=None) == models.Q(type__exact='bulk')
 
         # Ensure value does not translate to a Q argument
         criteria = {'lookup': 'exact', 'value': unstick_value}
-        assert filter.translate_to_Q_arg(**criteria, queryset=None) == None
+        assert filter.transmute(**criteria, queryset=None) == None
 
         # Check the default Q argument
-        assert filter.get_sticky_Q_arg(queryset=None) == ('type__exact', default_value)
+        assert filter.get_sticky_Q(queryset=None) == models.Q(type__exact=default_value)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -159,7 +159,7 @@ class TestFilter:
         )
 
         # Check options schema output
-        options_schema_info = filter.get_options_schema_info(field)
+        options_schema_info = filter.get_options_schema_info(field, queryset=None)
         expected = {
             'default_lookup': default_lookup,
             'label': label,
@@ -193,7 +193,7 @@ class TestFilter:
 
         # Check translation of _query data's criteria_ to django Q argument
         criteria = {'lookup': 'gte', 'value': '50'}
-        assert filter.translate_to_Q_arg(**criteria) == ('pages__gte', '50')
+        assert filter.translate_to_Q_arg(**criteria, queryset=None) == ('pages__gte', '50')
 
 
 class TestStickyFilter:
@@ -226,11 +226,11 @@ class TestStickyFilter:
 
         # Check translation of query data's criteria to django Q argument
         criteria = {'lookup': 'exact', 'value': 'bulk'}
-        assert filter.translate_to_Q_arg(**criteria) == ('type__exact', 'bulk')
+        assert filter.translate_to_Q_arg(**criteria, queryset=None) == ('type__exact', 'bulk')
 
         # Ensure value does not translate to a Q argument
         criteria = {'lookup': 'exact', 'value': unstick_value}
-        assert filter.translate_to_Q_arg(**criteria) == None
+        assert filter.translate_to_Q_arg(**criteria, queryset=None) == None
 
         # Check the default Q argument
-        assert filter.get_sticky_Q_arg() == ('type__exact', default_value)
+        assert filter.get_sticky_Q_arg(queryset=None) == ('type__exact', default_value)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -210,15 +210,15 @@ class TestStickyFilter:
             ('manual', 'Manual'),
             ('bulk', 'Bulk'),
         ]
-        unstick_value = 'any'
-        default_value = 'manual'
+        solvent_value = 'any'
+        sticky_value = 'manual'
 
         # Create the filter
-        filter = filters.StickyFilter(
+        filter = filters.Filter(
             filters.ChoiceLookup('exact', label='is', choices=choices),
             label=label,
-            unstick_value=unstick_value,
-            default_value=default_value,
+            solvent_value=solvent_value,
+            sticky_value=sticky_value,
         )
         # Manually set the Filter's name attribute,
         # which is otherwise handled by the FilterSet metaclass.
@@ -229,8 +229,8 @@ class TestStickyFilter:
         assert filter.transmute(**criteria, queryset=None) == models.Q(type__exact='bulk')
 
         # Ensure value does not translate to a Q argument
-        criteria = {'lookup': 'exact', 'value': unstick_value}
+        criteria = {'lookup': 'exact', 'value': solvent_value}
         assert filter.transmute(**criteria, queryset=None) == None
 
         # Check the default Q argument
-        assert filter.get_sticky_Q(queryset=None) == models.Q(type__exact=default_value)
+        assert filter.get_sticky_Q(queryset=None) == models.Q(type__exact=sticky_value)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -24,6 +24,18 @@ class TestInputLookup:
         expected = {'type': 'input', 'label': label}
         assert options_schema_blurb == expected
 
+    def test_transmute(self):
+        lookup_name = 'gte'
+        label = ">="
+        filter_name = 'count'
+        filter = mock.Mock()
+        filter.name = filter_name
+        lookup = filters.InputLookup(lookup_name, label=label)
+        criteria = {'value': 10, 'lookup': lookup_name}
+
+        # Target
+        assert lookup.transmute(filter=filter, criteria=criteria) == models.Q(count__gte=10)
+
 
 class TestChoiceLookup:
     """
@@ -107,6 +119,19 @@ class TestChoiceLookup:
             'choices': static_choices,
         }
         assert options_schema_blurb == expected
+
+    def test_transmute(self):
+        lookup_name = 'gte'
+        label = ">="
+        filter_name = 'count'
+        filter = mock.Mock()
+        filter.name = filter_name
+        choices = [(10, 'diez'), (25, 'veinticinco'), (50, 'cincuenta'), (100, 'ciento')]
+        lookup = filters.ChoiceLookup(lookup_name, label=label, choices=choices)
+        criteria = {'value': 10, 'lookup': lookup_name}
+
+        # Target
+        assert lookup.transmute(filter=filter, criteria=criteria) == models.Q(count__gte=10)
 
 
 class TestFilter:

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -233,7 +233,7 @@ class TestFilter:
         model = mock.MagicMock()
         filterset._meta.model = model
         model._meta.get_field.return_value = field
-        filter = filter.bind(filter_field_name, filterset)
+        filter = filter.bind(filter_field_name)
 
         # Check options schema output
         context = {'filterset': filterset, 'filter': filter, 'queryset': None}
@@ -271,7 +271,7 @@ class TestFilter:
         # Mock the bound (i.e. `Filter.bind`) instance of the filter.
         filterset = mock.MagicMock()
         filterset._meta.model._meta.get_field.side_effect = FieldDoesNotExist()
-        filter = filter.bind(filter_name, filterset)
+        filter = filter.bind(filter_name)
 
         # Check options schema output
         context = {'filterset': filterset, 'filter': filter, 'queryset': None}
@@ -308,7 +308,7 @@ class TestFilter:
             *[cls(*a, **kw) for cls, a, kw in lookups_data],
             label=label,
         )
-        filter = filter.bind(name='pages', filterset=None)
+        filter = filter.bind(name='pages')
 
         # Check translation of _query data's criteria_ to django Q argument
         criteria = {'lookup': 'gte', 'value': '50'}
@@ -368,7 +368,7 @@ class TestStickyFilter:
         )
         # Manually set the Filter's name attribute,
         # which is otherwise handled by the FilterSet metaclass.
-        filter = filter.bind(name='type', filterset=None)
+        filter = filter.bind(name='type')
 
         # Check translation of query data's criteria to django Q argument
         criteria = {'lookup': 'exact', 'value': 'bulk'}

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -244,6 +244,23 @@ class TestFilter:
         criteria = {'lookup': 'gte', 'value': '50'}
         assert filter.transmute(**criteria, queryset=None) == models.Q(pages__gte='50')
 
+    def test_valid_json_types(self):
+        # TODO Expand this test to cover native json types: number, null, array, and object.
+
+        def assertion_transmuter(value, queryset, **kwargs):
+            from django.db.models import Q
+
+            assert isinstance(value, bool)
+            return Q(something__in=['a', 'b', 'c'])
+
+        filter = filters.Filter(
+            filters.ChoiceLookup('exact', label=":", choices=((True, 'Yes'), (False, 'No'))),
+            label='Has something?',
+            transmuter=assertion_transmuter,
+        )
+        criteria = {'lookup': 'exact', 'value': True}
+        assert filter.transmute(**criteria, queryset=None)
+
 
 class TestStickyFilter:
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -242,15 +242,21 @@ class TestFilter:
 
         # Check translation of _query data's criteria_ to django Q argument
         criteria = {'lookup': 'gte', 'value': '50'}
-        assert filter.transmute(**criteria, queryset=None) == models.Q(pages__gte='50')
+        context = {
+            'filterset': None,  # not needed for this test
+            'filter': filter,
+            'queryset': None,  # not needed for this test
+            'criteria': criteria,
+        }
+        assert filter.transmute(**context) == models.Q(pages__gte='50')
 
     def test_valid_json_types(self):
         # TODO Expand this test to cover native json types: number, null, array, and object.
 
-        def assertion_transmuter(value, queryset, **kwargs):
+        def assertion_transmuter(criteria, **kwargs):
             from django.db.models import Q
 
-            assert isinstance(value, bool)
+            assert isinstance(criteria['value'], bool)
             return Q(something__in=['a', 'b', 'c'])
 
         filter = filters.Filter(
@@ -259,7 +265,13 @@ class TestFilter:
             transmuter=assertion_transmuter,
         )
         criteria = {'lookup': 'exact', 'value': True}
-        assert filter.transmute(**criteria, queryset=None)
+        context = {
+            'filterset': None,  # not needed for this test
+            'filter': filter,
+            'queryset': None,  # not needed for this test
+            'criteria': criteria,
+        }
+        assert filter.transmute(**context)
 
 
 class TestStickyFilter:
@@ -292,11 +304,23 @@ class TestStickyFilter:
 
         # Check translation of query data's criteria to django Q argument
         criteria = {'lookup': 'exact', 'value': 'bulk'}
-        assert filter.transmute(**criteria, queryset=None) == models.Q(type__exact='bulk')
+        context = {
+            'filterset': None,  # not needed for this test
+            'filter': filter,
+            'queryset': None,  # not needed for this test
+            'criteria': criteria,
+        }
+        assert filter.transmute(**context) == models.Q(type__exact='bulk')
 
         # Ensure value does not translate to a Q argument
         criteria = {'lookup': 'exact', 'value': solvent_value}
-        assert filter.transmute(**criteria, queryset=None) == None
+        context = {
+            'filterset': None,  # not needed for this test
+            'filter': filter,
+            'queryset': None,  # not needed for this test
+            'criteria': criteria,
+        }
+        assert filter.transmute(**context) == None
 
         # Check the default Q argument
         assert filter.get_sticky_Q(queryset=None) == models.Q(type__exact=sticky_value)

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -214,13 +214,13 @@ class TestFilterSetTranslatesQueryData:
             {"lookup": "icontains", "value": "stove"},
         )
         filterset = ProductFilterSet(data)
-        q = filterset._make_Q(filterset.query_data)
+        q = filterset._make_Q(filterset.query_data, queryset=None)
         expected = Q(("name__icontains", "stove"), _connector=Q.AND)
         assert q == expected
 
         data = ("not", ("name", {"lookup": "icontains", "value": "stove"}))
         filterset = ProductFilterSet(data)
-        q = filterset._make_Q(filterset.query_data)
+        q = filterset._make_Q(filterset.query_data, queryset=None)
         expected = Q(("name__icontains", "stove"), _connector=Q.AND, _negated=True)
         assert q == expected
 
@@ -241,7 +241,7 @@ class TestFilterSetTranslatesQueryData:
             ),
         )
         filterset = ProductFilterSet(data)
-        q = filterset._make_Q(filterset.query_data)
+        q = filterset._make_Q(filterset.query_data, queryset=None)
         expected = ~(Q(name__icontains="stove") | Q(name__icontains="oven"))
         assert q == expected
 
@@ -259,7 +259,7 @@ class TestFilterSetTranslatesQueryData:
             ),
         )
         filterset = ProductFilterSet(data)
-        q = filterset._make_Q(filterset.query_data)
+        q = filterset._make_Q(filterset.query_data, queryset=None)
         expected = Q(name__icontains="stove") | (
             Q(name__icontains="oven") & ~Q(name__icontains="microwave")
         )
@@ -288,7 +288,7 @@ class TestFilterSetTranslatesQueryData:
             ),
         )
         filterset = ProductFilterSet(data)
-        q = filterset._make_Q(filterset.query_data)
+        q = filterset._make_Q(filterset.query_data, queryset=None)
         expected = (
             Q(category__in=["Kitchen", "Bath"])
             & Q(stocked__year__gte="2024")
@@ -310,7 +310,7 @@ class TestFilterSetTranslatesQueryData:
         data = []
         filterset = KitchenProductFilterSet(data)
         assert filterset.is_valid
-        q = filterset._query
+        q = filterset.get_query(queryset=None)
         # Expect the sticky filter to be added to the query
         expected = Q(("category__exact", "Kitchen"), _connector=Q.AND)
         assert q == expected
@@ -327,7 +327,7 @@ class TestFilterSetTranslatesQueryData:
         ]
         filterset = KitchenProductFilterSet(data)
         filterset.validate()
-        q = filterset._query
+        q = filterset.get_query(queryset=None)
         # Expect the sticky filter to be added to the query
         expected = Q(("category__exact", "Kitchen")) & Q(("name__icontains", "sink"), _connector=Q.AND)
         assert q == expected
@@ -346,7 +346,7 @@ class TestFilterSetTranslatesQueryData:
         ]
         filterset = KitchenProductFilterSet(data)
         filterset.validate()
-        q = filterset._query
+        q = filterset.get_query(queryset=None)
         # Expect the sticky filter to be present
         expected = Q(("category__exact", "Kitchen")) & Q(("name__icontains", "sink"), _connector=Q.AND)
         assert q == expected
@@ -365,7 +365,7 @@ class TestFilterSetTranslatesQueryData:
         ]
         filterset = KitchenProductFilterSet(data)
         filterset.validate()
-        q = filterset._query
+        q = filterset.get_query(queryset=None)
         # Expect the sticky filter to be present
         expected = Q(("category__exact", "Bath")) & Q(("name__icontains", "sink"), _connector=Q.AND)
         assert q == expected
@@ -388,7 +388,7 @@ class TestFilterSetTranslatesQueryData:
         ]
         filterset = KitchenProductFilterSet(data)
         filterset.validate()
-        q = filterset._query
+        q = filterset.get_query(queryset=None)
         # Expect the sticky filter NOT to be present
         expected = Q(("name__icontains", "sink"), _connector=Q.AND)
         assert q == expected
@@ -396,7 +396,7 @@ class TestFilterSetTranslatesQueryData:
     def test_several_sticky_filters__without_query_data(self):
         filterset = TopBrandKitchenProductFilterSet()
         assert filterset.is_valid
-        q = filterset._query
+        q = filterset.get_query(queryset=None)
         # Expect the sticky filter(s) to be present
         expected = Q(
             ('category__exact', 'Kitchen'),
@@ -414,7 +414,7 @@ class TestFilterSetTranslatesQueryData:
         ]
         filterset = TopBrandKitchenProductFilterSet(data)
         filterset.validate()
-        q = filterset._query
+        q = filterset.get_query(queryset=None)
         # Expect the sticky filter(s) to be present
         expected = Q(
             ('category__exact', 'Kitchen'),
@@ -434,7 +434,7 @@ class TestFilterSetTranslatesQueryData:
         ]
         filterset = TopBrandKitchenProductFilterSet(data)
         filterset.validate()
-        q = filterset._query
+        q = filterset.get_query(queryset=None)
         # Expect the sticky filter(s) to be present
         # Note, the order of these might seem wrong,
         # because 'category' was defined before 'brand',
@@ -457,7 +457,7 @@ class TestFilterSetTranslatesQueryData:
         ]
         filterset = TopBrandKitchenProductFilterSet(data)
         filterset.validate()
-        q = filterset._query
+        q = filterset.get_query(queryset=None)
         # Expect the sticky filters to be present
         expected = (
             Q(("category__exact", "Bath"))
@@ -479,7 +479,7 @@ class TestFilterSetTranslatesQueryData:
         ]
         filterset = TopBrandKitchenProductFilterSet(data)
         filterset.validate()
-        q = filterset._query
+        q = filterset.get_query(queryset=None)
         # Expect the sticky filters NOT to be present
         expected = Q(("name__icontains", "faucet"), _connector=Q.AND)
         assert q == expected
@@ -505,7 +505,7 @@ class TestFilterSetQueryData:
         # Target
         assert filterset.is_valid, filterset.errors
         expected = Q(("name__icontains", "har"), _connector=Q.AND)
-        assert filterset.query == expected
+        assert filterset.get_query(queryset=None) == expected
 
     def test_invalid_toplevel_operator(self):
         data = [

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -229,9 +229,9 @@ class TestFilterQuerySet:
         assert list(qs) == [self.participants[-1]]
 
 
-class TestFilterSetTranslatesQueryData:
+class TestFilterSetTransmutesQueryData:
     """
-    Test the ``FilterSet._make_Q`` method translates the query data to a ``Q`` object.
+    Test the ``FilterSet._make_Q`` method transmutes the query data to a ``Q`` object.
     """
 
     def test(self):

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -656,3 +656,22 @@ class TestFilterSetQueryData:
 
         with pytest.raises(InvalidFilterSet):
             filterset.filter_queryset(Participant.objects.all())
+
+    def test_with_boolean_query_data_values(self):
+        """
+        Tests the usage of boolean values in the query data.
+        """
+        data = [
+            "and",
+            [
+                ["is_in_stock", {"lookup": "exact", "value": True}],
+            ],
+        ]
+        filterset = ProductFilterSet(data)
+        q = filterset._transmute(filterset.query_data, queryset=None)
+
+        assert filterset.is_valid, filterset.errors
+        expected = (
+            Q(quantity__gt=0)
+        )
+        assert q == expected

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -398,11 +398,11 @@ class TestFilterSetTranslatesQueryData:
         This test case essentially tests for the removal
         of the sticky filter from the overall query.
         """
-        unstick_user_value = KitchenProductFilterSet._meta.sticky_filters[0].unstick_value
+        solvent_user_value = KitchenProductFilterSet._meta.sticky_filters[0].solvent_value
         data = [
             "and",
             [
-                ["category", {"lookup": "exact", "value": unstick_user_value}],
+                ["category", {"lookup": "exact", "value": solvent_user_value}],
                 ["name", {"lookup": "icontains", "value": "sink"}],
             ],
         ]
@@ -487,13 +487,13 @@ class TestFilterSetTranslatesQueryData:
         assert q == expected
 
     def test_several_sticky_filters__unstick_value_in_query_data(self):
-        category_unstick_user_value = TopBrandKitchenProductFilterSet._meta.get_filter('category').unstick_value
-        brand_unstick_user_value = TopBrandKitchenProductFilterSet._meta.get_filter('brand').unstick_value
+        category_solvent_user_value = TopBrandKitchenProductFilterSet._meta.get_filter('category').solvent_value
+        brand_solvent_user_value = TopBrandKitchenProductFilterSet._meta.get_filter('brand').solvent_value
         data = [
             "and",
             [
-                ["brand", {"lookup": "exact", "value": brand_unstick_user_value}],
-                ["category", {"lookup": "exact", "value": category_unstick_user_value}],
+                ["brand", {"lookup": "exact", "value": brand_solvent_user_value}],
+                ["category", {"lookup": "exact", "value": category_solvent_user_value}],
                 ["name", {"lookup": "icontains", "value": "faucet"}],
             ],
         ]

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -174,7 +174,7 @@ class TestFilterQuerySet:
     def test_empty_filter_queryset(self):
         filterset = ParticipantFilterSet()
         # Target
-        qs = filterset.filter_queryset()
+        qs = filterset.filter_queryset(Participant.objects.all())
         # Check result is a non-filtered result of either
         # the queryset argument or the base queryset.
         asserts.assertQuerySetEqual(qs, Participant.objects.all())
@@ -185,7 +185,7 @@ class TestFilterQuerySet:
         filterset = ParticipantFilterSet(query_data)
 
         # Target
-        qs = filterset.filter_queryset()
+        qs = filterset.filter_queryset(Participant.objects.all())
 
         expected_qs = Participant.objects.filter(name__icontains=filter_value).all()
         # Check queryset equality
@@ -595,4 +595,4 @@ class TestFilterSetQueryData:
         filterset = ParticipantFilterSet(data)
 
         with pytest.raises(InvalidFilterSet):
-            filterset.filter_queryset()
+            filterset.filter_queryset(Participant.objects.all())

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -299,7 +299,7 @@ class TestFilterSetTranslatesQueryData:
             "and",
             (
                 ("category", {"lookup": "in", "value": ["Kitchen", "Bath"]}),
-                ("stocked", {"lookup": ["year", "gte"], "value": "2024"}),
+                ("stocked_on", {"lookup": ["year", "gte"], "value": "2024"}),
                 (
                     "or",
                     (
@@ -321,7 +321,7 @@ class TestFilterSetTranslatesQueryData:
         q = filterset._transmute(filterset.query_data, queryset=None)
         expected = (
             Q(category__in=["Kitchen", "Bath"])
-            & Q(stocked__year__gte="2024")
+            & Q(stocked_on__year__gte="2024")
             & (
                 (
                     Q(name__icontains="soap")

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -234,13 +234,13 @@ class TestFilterSetTranslatesQueryData:
             {"lookup": "icontains", "value": "stove"},
         )
         filterset = ProductFilterSet(data)
-        q = filterset._make_Q(filterset.query_data, queryset=None)
+        q = filterset._transmute(filterset.query_data, queryset=None)
         expected = Q(("name__icontains", "stove"), _connector=Q.AND)
         assert q == expected
 
         data = ("not", ("name", {"lookup": "icontains", "value": "stove"}))
         filterset = ProductFilterSet(data)
-        q = filterset._make_Q(filterset.query_data, queryset=None)
+        q = filterset._transmute(filterset.query_data, queryset=None)
         expected = Q(("name__icontains", "stove"), _connector=Q.AND, _negated=True)
         assert q == expected
 
@@ -261,7 +261,7 @@ class TestFilterSetTranslatesQueryData:
             ),
         )
         filterset = ProductFilterSet(data)
-        q = filterset._make_Q(filterset.query_data, queryset=None)
+        q = filterset._transmute(filterset.query_data, queryset=None)
         expected = ~(Q(name__icontains="stove") | Q(name__icontains="oven"))
         assert q == expected
 
@@ -279,7 +279,7 @@ class TestFilterSetTranslatesQueryData:
             ),
         )
         filterset = ProductFilterSet(data)
-        q = filterset._make_Q(filterset.query_data, queryset=None)
+        q = filterset._transmute(filterset.query_data, queryset=None)
         expected = Q(name__icontains="stove") | (
             Q(name__icontains="oven") & ~Q(name__icontains="microwave")
         )
@@ -308,7 +308,7 @@ class TestFilterSetTranslatesQueryData:
             ),
         )
         filterset = ProductFilterSet(data)
-        q = filterset._make_Q(filterset.query_data, queryset=None)
+        q = filterset._transmute(filterset.query_data, queryset=None)
         expected = (
             Q(category__in=["Kitchen", "Bath"])
             & Q(stocked__year__gte="2024")
@@ -520,7 +520,7 @@ class TestFilterSetTranslatesQueryData:
         )
         # The StudyFilterSet.continent filter has a custom translator assigned to it.
         filterset = StudyFilterSet(query_data)
-        q = filterset._make_Q(filterset.query_data, queryset=None)
+        q = filterset._transmute(filterset.query_data, queryset=None)
 
         # Incomplete list of ISO 1366-1 alpha-3 country codes for North America
         expected_country_codes = ['CAN', 'MEX', 'USA', 'BMU', 'GRL']

--- a/tests/test_filterset.py
+++ b/tests/test_filterset.py
@@ -234,7 +234,7 @@ class TestFilterSetTransmutesQueryData:
     Test the ``FilterSet._make_Q`` method transmutes the query data to a ``Q`` object.
     """
 
-    def test(self):
+    def test_simplest_case(self):
         # Simple test case that isn't actually valid query data,
         # because the value of the root array must be a boolean operation
         # (e.g. and, or, not).
@@ -248,12 +248,14 @@ class TestFilterSetTransmutesQueryData:
         expected = Q(("name__icontains", "stove"), _connector=Q.AND)
         assert q == expected
 
+    def test_notting(self):
         data = ("not", ("name", {"lookup": "icontains", "value": "stove"}))
         filterset = ProductFilterSet(data)
         q = filterset._transmute(filterset.query_data, queryset=None)
         expected = Q(("name__icontains", "stove"), _connector=Q.AND, _negated=True)
         assert q == expected
 
+    def test_notted_oring(self):
         data = (
             "not",
             (
@@ -275,6 +277,7 @@ class TestFilterSetTransmutesQueryData:
         expected = ~(Q(name__icontains="stove") | Q(name__icontains="oven"))
         assert q == expected
 
+    def test_grouped_conditions(self):
         data = (
             "or",
             (
@@ -295,6 +298,7 @@ class TestFilterSetTransmutesQueryData:
         )
         assert q == expected
 
+    def test_deep_grouped_conditions(self):
         data = (
             "and",
             (

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -58,6 +58,7 @@ class TestJsonSchema:
         assert schema['$defs']['filters']['anyOf'] == expected
 
         # Look for the particular filters
+        valid_value_types = ["string", "number", "object", "array", "boolean", "null"]
         expected_age_filter = {
             'type': 'array',
             'prefixItems': [
@@ -66,7 +67,7 @@ class TestJsonSchema:
                     'type': 'object',
                     'properties': {
                         'lookup': {'enum': valid_filters['age']},
-                        'value': {'type': 'string'}
+                        'value': {'type': valid_value_types}
                     }
                 }
             ]
@@ -80,7 +81,7 @@ class TestJsonSchema:
                     'type': 'object',
                     'properties': {
                         'lookup': {'enum': valid_filters['sex']},
-                        'value': {'type': 'string'}
+                        'value': {'type': valid_value_types}
                     }
                 }
             ]

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -9,7 +9,8 @@ from django_filtering.filterset import FilterSet
 from django_filtering.schema import FilteringOptionsSchema, JSONSchema
 
 from tests.lab_app import models
-from tests.lab_app.filters import ParticipantFilterSet
+from tests.lab_app.filters import ParticipantFilterSet, StudyFilterSet
+from tests.lab_app.utils import CONTINENT_CHOICES
 from tests.market_app.filters import TopBrandKitchenProductFilterSet
 
 
@@ -269,3 +270,34 @@ class TestFilteringOptionsSchema:
         # Check for filters
         for name, info in expected_schema.items():
             assert schema.schema['filters'][name] == info
+
+    def test_generation_of_schema_with_non_field_filters(self):
+        expected_filters = {
+            'continent': {
+                'default_lookup': 'exact',
+                'label': 'Continent',
+                'lookups': {
+                    'exact': {
+                        'choices': CONTINENT_CHOICES,
+                        'label': 'is',
+                        'type': 'choice',
+                    },
+                },
+            },
+            'name': {
+                'default_lookup': 'icontains',
+                'label': 'Name',
+                'lookups': {'icontains': {'label': 'contains', 'type': 'input'},
+                },
+            },
+        }
+
+        filterset = StudyFilterSet()
+        schema = FilteringOptionsSchema(filterset)
+
+        # Check for the valid FilterSet
+        assert sorted(schema.schema['filters'].keys()) == sorted(expected_filters.keys())
+
+        # Check for filters
+        assert schema.schema['filters']['name'] == expected_filters['name']
+        assert schema.schema['filters']['continent'] == expected_filters['continent']

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,8 @@
+from django.db.models import Q
+
 from django_filtering.utils import (
     construct_field_lookup_arg,
-    deconstruct_field_lookup_arg,
+    deconstruct_query,
     merge_dicts,
 )
 
@@ -31,7 +33,7 @@ def test_deconstruct_field_lookup_arg():
     # Note, when a lookup is not provided, it defaults to 'exact'.
     # Django defaults to 'exact' in the backend. Here we are simply explicit about it.
     expected = ['state', {'lookup': 'exact', 'value': 'Complete'}]
-    assert deconstruct_field_lookup_arg('state', 'Complete') == expected
+    assert deconstruct_query(Q(state='Complete')) == expected
 
     expected = ['name', {'lookup': 'icontains', 'value': 'foo'}]
-    assert deconstruct_field_lookup_arg('name', 'foo', 'icontains') == expected
+    assert deconstruct_query(Q(name__icontains='foo')) == expected


### PR DESCRIPTION
Provides the developer with the ability to define logic to transform, change, or _transmute_ the recieved data into a `Q` instance, which is then used by Django to filter the `QuerySet`. The goal was to provide an interface that did not require the developer to subclass `Filter` in order to define this custom logic. The process to transform _query data_ to `Q` instances is _transmutation_.

## Why is transmutation a desired feature?

The original usecase is to allow for the definition of logic that would transform query data into a `Q` instance for non-model fields. This might include things like api quieries, cross database lookups, or some other source of information used to build a query against the filterset's model.

Another usecase is to allow for the use of complex values given by the client. For example, a `DateRangeLookup` has been added in this changeset to provide the ability to search a model date field for dates between the given criteria. This information is submitted as a JSON array rather than a string. The transmutation logic is able to condense what would have been two query items into one.

## The transmutation feature details

Transmutation can be done in one of two ways. The first primative method is to declare a function or callable during filter instantiation: `Filter(..., transmuter=<callable>)`. This method is not the advised or recommended way of customizing.

To encapsulate the developer's customizations, the `FilterSet` has the concept of transmute methods. These are methods named as `transmute_<filter-name>[__<lookup...>]`. The filter set will use the transmute method in place of the default logic provided by the `Filter`.

In either of these cases the result is a `Q` instance that will be consumed into the broader query by the `FilterSet`.

For example, a basic transmute method looks something like this:

```py
class FilterSet(FilterSet):
    # ...
    organization = Filter(
        InputLookup("icontains", label="contains"),
        label="Organization",
    )

    def transmute_organization(self, criteria, context):
        value = criteria['value']
        # Assume Organization is in a separate database
        # from the FilterSet's model.
        qs = Organization.objects.all()
        qs = qs.filter(name__icontains=value)
        qs = qs.order_by().values_list('pk', flat=True)
        return Q(organization_id__in=list(qs))
```

The transmute method takes two arguments `criteria: dict[str, Any]` and `context: dict[str, Any]`. The `criteria` is the criteria portion of condition row from the client (e.g. `{'value': 'foo', 'lookup': 'iexact'}`).

The `context` is a dictionary of metadata that can be used in support of decision making. The context includes: `queryset: QuerySet`, `filter: Filter`, and `filterset: FilterSet`. This should provide enough context to the transmutation method to make any decisions needed. For instance, it's possible to make querying decisions given a queryset for a completely different model than the filterset was created for.

Furthermore, it's possible to create several transmute methods for each of the defined lookups of a Filter. These methods are then named more specifically and will be found first in the transmutation resolution path. For example, if the aforementioned filter had other lookups defined, one might change the method name to `transmute_organization__icontains`.

## A less apparent changes...

A less apparent change is the Filter handing by the FilterSetType (metaclass). The filters have been moved to a parentage lookup pattern. This is similar to how some of the Django machinery works. It has the prospective advantage of being able to point to the specific declaration heritage if there is an error. That is not a need at this time, but I like the idea of not erasing heredity as I was doing before.

# The removal of StickyFilter

The `Filter` class has incorporated the `StickyFilter` class features. As a result, the `StickyFilter` class has been removed. The sticky filter feature is now available through the use of the `sticky_value` and `solvent_value` arguments. The `sticky_value` designates the default value to use. The `solvent_value` is used to remove the sticky filter from the overall query.

## The new DateRangeLookup

A fairly comprehesive example of the recent changes is the new `DateRangeLookup`. This provides the user with the input for a start and end date to query between.
It's a unique addition in that development up to this point has been single value based.

The `DateRangeLookup` expects the client's submitted value criteria to be a two value array. Up to this point in development all criteria values have been a string. This exercises and demostrates both the `clean` and `transmute` methods of `Filter` and `Lookup`.
