### PR TITLE
Fix bug where queryset was evaluated in a boolean context.

### DIFF
--- a/src/django_filtering/filterset.py
+++ b/src/django_filtering/filterset.py
@@ -213,9 +213,11 @@ class FilterSet(metaclass=FilterSetType):
         return q
 
     def make_context(self, filter, queryset=None) -> dict[str, Any]:
+        if queryset is None:
+            queryset = self.get_default_queryset()
         return {
             'filterset': self,
-            'queryset': queryset or self.get_default_queryset(),
+            'queryset': queryset,
             'filter': filter,
         }
 


### PR DESCRIPTION
The previous code evaluated a queryset in a boolean context, which effectively meant we were doing a `select *` with no where clause on whatever the underlying table was. If that table is very large it could result in a very slow response or even an OOM error.

See the note about `bool()` at the end of this section:  
https://docs.djangoproject.com/en/5.2/ref/models/querysets/#when-querysets-are-evaluated

FWIW I think this is easily one of the worst footguns in Django.